### PR TITLE
Liquid.Cache has no Tests project to run, so remove tests from CI/CD

### DIFF
--- a/.github/workflows/liquid-ci-cd.yml
+++ b/.github/workflows/liquid-ci-cd.yml
@@ -75,8 +75,6 @@ jobs:
       run: |
         dotnet sonarscanner begin /k:"Avanade_Liquid.Cache" /o:"avanade-1" /d:sonar.login="${{secrets.SONAR_TOKEN}}" /d:sonar.host.url="https://sonarcloud.io" /d:sonar.cs.vstest.reportsPaths=$GITHUB_WORKSPACE/testresults/*.trx /d:sonar.coverageReportPaths=$GITHUB_WORKSPACE/coverlet/reports/SonarQube.xml
         dotnet build src/Liquid.Cache.sln --configuration Release --no-restore
-        dotnet test src/Liquid.Cache.Tests/*Tests.csproj --collect:"XPlat Code Coverage" --logger trx --results-directory $GITHUB_WORKSPACE/testresults
-        reportgenerator -reports:$GITHUB_WORKSPACE/testresults/**/coverage.cobertura.xml -targetdir:$GITHUB_WORKSPACE/coverlet/reports -reporttypes:"SonarQube"
         dotnet sonarscanner end /d:sonar.login="${{secrets.SONAR_TOKEN}}"
     - name: (CD) Nuget Pack & Push to Nuget.org
       if: ${{ github.event_name == 'push' }}


### PR DESCRIPTION
It's ok to not have tests since it's only an Interface and an Exception class