### PR TITLE
removing Code Coverage extra.properties from sonar-scanner begin

### DIFF
--- a/.github/workflows/liquid-ci-cd.yml
+++ b/.github/workflows/liquid-ci-cd.yml
@@ -73,7 +73,7 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
         SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
       run: |
-        dotnet sonarscanner begin /k:"Avanade_Liquid.Cache" /o:"avanade-1" /d:sonar.login="${{secrets.SONAR_TOKEN}}" /d:sonar.host.url="https://sonarcloud.io" /d:sonar.cs.vstest.reportsPaths=$GITHUB_WORKSPACE/testresults/*.trx /d:sonar.coverageReportPaths=$GITHUB_WORKSPACE/coverlet/reports/SonarQube.xml
+        dotnet sonarscanner begin /k:"Avanade_Liquid.Cache" /o:"avanade-1" /d:sonar.login="${{secrets.SONAR_TOKEN}}" /d:sonar.host.url="https://sonarcloud.io"
         dotnet build src/Liquid.Cache.sln --configuration Release --no-restore
         dotnet sonarscanner end /d:sonar.login="${{secrets.SONAR_TOKEN}}"
     - name: (CD) Nuget Pack & Push to Nuget.org


### PR DESCRIPTION
Since there are no tests anymore, the extra.properties was causing sonar-scanner to fail, because there are no coverage reports to send to Sonarcloud