### PR TITLE
spliting sonar projects for each different CI/CD job

### DIFF
--- a/.github/workflows/liquid-ci-cd-ignite-cartridge.yml
+++ b/.github/workflows/liquid-ci-cd-ignite-cartridge.yml
@@ -71,13 +71,13 @@ jobs:
     - name: (CI/CD) Build and Analyze Project
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
-        SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        SONAR_TOKEN: ${{ secrets.SONAR_TOKEN_IGNITE }}
       run: |
-        dotnet sonarscanner begin /k:"Avanade_Liquid.Cache" /o:"avanade-1" /d:sonar.login="${{secrets.SONAR_TOKEN}}" /d:sonar.host.url="https://sonarcloud.io" /d:sonar.cs.vstest.reportsPaths=$GITHUB_WORKSPACE/testresults/*.trx /d:sonar.coverageReportPaths=$GITHUB_WORKSPACE/coverlet/reports/SonarQube.xml
+        dotnet sonarscanner begin /k:"Avanade_Liquid.Cache.Ignite" /o:"avanade-1" /d:sonar.login="${{secrets.SONAR_TOKEN_IGNITE}}" /d:sonar.host.url="https://sonarcloud.io" /d:sonar.cs.vstest.reportsPaths=$GITHUB_WORKSPACE/testresults/*.trx /d:sonar.coverageReportPaths=$GITHUB_WORKSPACE/coverlet/reports/SonarQube.xml
         dotnet build src/Liquid.Cache.Ignite/Liquid.Cache.Ignite.csproj --configuration Release --no-restore
         dotnet test src/Liquid.Cache.Ignite.Tests/*Tests.csproj --collect:"XPlat Code Coverage" --logger trx --results-directory $GITHUB_WORKSPACE/testresults
         reportgenerator -reports:$GITHUB_WORKSPACE/testresults/**/coverage.cobertura.xml -targetdir:$GITHUB_WORKSPACE/coverlet/reports -reporttypes:"SonarQube"
-        dotnet sonarscanner end /d:sonar.login="${{secrets.SONAR_TOKEN}}"
+        dotnet sonarscanner end /d:sonar.login="${{secrets.SONAR_TOKEN_IGNITE}}"
     - name: (CD) Nuget Pack & Push to Nuget.org
       if: ${{ github.event_name == 'push' }}
       run: |

--- a/.github/workflows/liquid-ci-cd-memory-cartridge.yml
+++ b/.github/workflows/liquid-ci-cd-memory-cartridge.yml
@@ -71,13 +71,13 @@ jobs:
     - name: (CI/CD) Build and Analyze Project
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
-        SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        SONAR_TOKEN: ${{ secrets.SONAR_TOKEN_MEMORY }}
       run: |
-        dotnet sonarscanner begin /k:"Avanade_Liquid.Cache" /o:"avanade-1" /d:sonar.login="${{secrets.SONAR_TOKEN}}" /d:sonar.host.url="https://sonarcloud.io" /d:sonar.cs.vstest.reportsPaths=$GITHUB_WORKSPACE/testresults/*.trx /d:sonar.coverageReportPaths=$GITHUB_WORKSPACE/coverlet/reports/SonarQube.xml
+        dotnet sonarscanner begin /k:"Avanade_Liquid.Cache.Memory" /o:"avanade-1" /d:sonar.login="${{secrets.SONAR_TOKEN_MEMORY}}" /d:sonar.host.url="https://sonarcloud.io" /d:sonar.cs.vstest.reportsPaths=$GITHUB_WORKSPACE/testresults/*.trx /d:sonar.coverageReportPaths=$GITHUB_WORKSPACE/coverlet/reports/SonarQube.xml
         dotnet build src/Liquid.Cache.Memory/Liquid.Cache.Memory.csproj --configuration Release --no-restore
         dotnet test src/Liquid.Cache.Memory.Tests/*Tests.csproj --collect:"XPlat Code Coverage" --logger trx --results-directory $GITHUB_WORKSPACE/testresults
         reportgenerator -reports:$GITHUB_WORKSPACE/testresults/**/coverage.cobertura.xml -targetdir:$GITHUB_WORKSPACE/coverlet/reports -reporttypes:"SonarQube"
-        dotnet sonarscanner end /d:sonar.login="${{secrets.SONAR_TOKEN}}"
+        dotnet sonarscanner end /d:sonar.login="${{secrets.SONAR_TOKEN_MEMORY}}"
     - name: (CD) Nuget Pack & Push to Nuget.org
       if: ${{ github.event_name == 'push' }}
       run: |

--- a/.github/workflows/liquid-ci-cd-ncache-cartridge.yml
+++ b/.github/workflows/liquid-ci-cd-ncache-cartridge.yml
@@ -71,13 +71,13 @@ jobs:
     - name: (CI/CD) Build and Analyze Project
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
-        SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        SONAR_TOKEN: ${{ secrets.SONAR_TOKEN_NCACHE }}
       run: |
-        dotnet sonarscanner begin /k:"Avanade_Liquid.Cache" /o:"avanade-1" /d:sonar.login="${{secrets.SONAR_TOKEN}}" /d:sonar.host.url="https://sonarcloud.io" /d:sonar.cs.vstest.reportsPaths=$GITHUB_WORKSPACE/testresults/*.trx /d:sonar.coverageReportPaths=$GITHUB_WORKSPACE/coverlet/reports/SonarQube.xml
+        dotnet sonarscanner begin /k:"Avanade_Liquid.Cache.NCache" /o:"avanade-1" /d:sonar.login="${{secrets.SONAR_TOKEN_NCACHE}}" /d:sonar.host.url="https://sonarcloud.io" /d:sonar.cs.vstest.reportsPaths=$GITHUB_WORKSPACE/testresults/*.trx /d:sonar.coverageReportPaths=$GITHUB_WORKSPACE/coverlet/reports/SonarQube.xml
         dotnet build src/Liquid.Cache.NCache/Liquid.Cache.NCache.csproj --configuration Release --no-restore
         dotnet test src/Liquid.Cache.NCache.Tests/*Tests.csproj --collect:"XPlat Code Coverage" --logger trx --results-directory $GITHUB_WORKSPACE/testresults
         reportgenerator -reports:$GITHUB_WORKSPACE/testresults/**/coverage.cobertura.xml -targetdir:$GITHUB_WORKSPACE/coverlet/reports -reporttypes:"SonarQube"
-        dotnet sonarscanner end /d:sonar.login="${{secrets.SONAR_TOKEN}}"
+        dotnet sonarscanner end /d:sonar.login="${{secrets.SONAR_TOKEN_NCACHE}}"
     - name: (CD) Nuget Pack & Push to Nuget.org
       if: ${{ github.event_name == 'push' }}
       run: |

--- a/.github/workflows/liquid-ci-cd-redis-cartridge.yml
+++ b/.github/workflows/liquid-ci-cd-redis-cartridge.yml
@@ -77,13 +77,13 @@ jobs:
     - name: (CI/CD) Build and Analyze Project
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
-        SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        SONAR_TOKEN: ${{ secrets.SONAR_TOKEN_REDIS }}
       run: |
-        dotnet sonarscanner begin /k:"Avanade_Liquid.Cache" /o:"avanade-1" /d:sonar.login="${{secrets.SONAR_TOKEN}}" /d:sonar.host.url="https://sonarcloud.io" /d:sonar.cs.vstest.reportsPaths=$GITHUB_WORKSPACE/testresults/*.trx /d:sonar.coverageReportPaths=$GITHUB_WORKSPACE/coverlet/reports/SonarQube.xml
+        dotnet sonarscanner begin /k:"Avanade_Liquid.Cache.Redis" /o:"avanade-1" /d:sonar.login="${{secrets.SONAR_TOKEN_REDIS}}" /d:sonar.host.url="https://sonarcloud.io" /d:sonar.cs.vstest.reportsPaths=$GITHUB_WORKSPACE/testresults/*.trx /d:sonar.coverageReportPaths=$GITHUB_WORKSPACE/coverlet/reports/SonarQube.xml
         dotnet build src/Liquid.Cache.Redis/Liquid.Cache.Redis.csproj --configuration Release --no-restore
         dotnet test src/Liquid.Cache.Redis.Tests/*Tests.csproj --collect:"XPlat Code Coverage" --logger trx --results-directory $GITHUB_WORKSPACE/testresults
         reportgenerator -reports:$GITHUB_WORKSPACE/testresults/**/coverage.cobertura.xml -targetdir:$GITHUB_WORKSPACE/coverlet/reports -reporttypes:"SonarQube"
-        dotnet sonarscanner end /d:sonar.login="${{secrets.SONAR_TOKEN}}"
+        dotnet sonarscanner end /d:sonar.login="${{secrets.SONAR_TOKEN_REDIS}}"
 
     - name: (CD) Nuget Pack & Push to Nuget.org
       if: ${{ github.event_name == 'push' }}


### PR DESCRIPTION
Because Sonar was keeping only the analysis of the last run.
This way, each cartridge will have its own project on Sonarcloud.
So we will keep a one-to-many relationship between GitHub repos and Sonarcloud projects when we have more than one CI/CD job on the repo (usually the repos where we have cartridges)